### PR TITLE
Remove theme switcher

### DIFF
--- a/app.js
+++ b/app.js
@@ -1209,25 +1209,5 @@ document.addEventListener('keydown', e => {
   if (e.key === 'Escape') { closeModal(); closeVarModal(); closeDeleteModal(); }
 });
 
-// ===== THEME SWITCHER =====
-const THEMES = ['rose', 'ocean', 'amber'];
-
-function applyTheme(theme) {
-  if (theme === 'rose') {
-    document.documentElement.removeAttribute('data-theme');
-  } else {
-    document.documentElement.setAttribute('data-theme', theme);
-  }
-  document.querySelectorAll('.theme-dot').forEach(dot => {
-    dot.classList.toggle('active', dot.dataset.theme === theme);
-  });
-}
-
-document.getElementById('themeSwitcher').addEventListener('click', e => {
-  const dot = e.target.closest('.theme-dot');
-  if (!dot) return;
-  applyTheme(dot.dataset.theme);
-});
-
 // ===== INIT =====
 initAuth();

--- a/index.html
+++ b/index.html
@@ -53,12 +53,7 @@
         </div>
       </div>
       <div class="progress-summary" id="progressSummary"></div>
-      <div class="theme-switcher" id="themeSwitcher" aria-label="Choose theme">
-        <button class="theme-dot active" data-theme="rose"  title="Dark Rose" aria-label="Dark Rose theme"></button>
-        <button class="theme-dot"        data-theme="ocean" title="Midnight Ocean" aria-label="Midnight Ocean theme"></button>
-        <button class="theme-dot"        data-theme="amber" title="Amber Dusk" aria-label="Amber Dusk theme"></button>
-      </div>
-      <div class="user-info" id="userInfo">
+<div class="user-info" id="userInfo">
         <span class="user-email" id="userEmailDisplay"></span>
         <button class="logout-btn" id="logoutBtn">Log out</button>
       </div>

--- a/style.css
+++ b/style.css
@@ -25,33 +25,6 @@
   --l5: #8e44ad;
 }
 
-/* ===== THEME: Midnight Ocean ===== */
-:root[data-theme="ocean"] {
-  --bg:          #080f1a;
-  --surface:     #0d1b2e;
-  --surface2:    #132540;
-  --border:      #1d3252;
-  --accent:      #0d7fc2;
-  --accent2:     #38bdf8;
-  --text:        #e4f1fb;
-  --text-muted:  #5e88a8;
-  --header-grad: linear-gradient(135deg, #04090f 0%, #0d1b2e 100%);
-  --title-grad:  linear-gradient(135deg, #38bdf8, #0d7fc2);
-}
-
-/* ===== THEME: Amber Dusk ===== */
-:root[data-theme="amber"] {
-  --bg:          #0d0b07;
-  --surface:     #191408;
-  --surface2:    #221c0c;
-  --border:      #332a12;
-  --accent:      #b87c10;
-  --accent2:     #f5a623;
-  --text:        #f5f0e8;
-  --text-muted:  #8a7a56;
-  --header-grad: linear-gradient(135deg, #080600 0%, #191408 100%);
-  --title-grad:  linear-gradient(135deg, #f5a623, #b87c10);
-}
 
 body {
   font-family: 'Segoe UI', system-ui, sans-serif;
@@ -796,30 +769,6 @@ main {
 }
 .logout-btn:hover { color: var(--text); border-color: #4a4a62; }
 
-/* ===== THEME SWITCHER ===== */
-.theme-switcher {
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-  flex-shrink: 0;
-}
-
-.theme-dot {
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  border: 2px solid transparent;
-  cursor: pointer;
-  transition: transform 0.15s, border-color 0.15s;
-  padding: 0;
-  background-clip: padding-box;
-}
-.theme-dot:hover { transform: scale(1.2); }
-.theme-dot.active { border-color: var(--text); transform: scale(1.15); }
-
-.theme-dot[data-theme="rose"]  { background: #c0436a; }
-.theme-dot[data-theme="ocean"] { background: #0d7fc2; }
-.theme-dot[data-theme="amber"] { background: #b87c10; }
 
 /* ===== RESPONSIVE ===== */
 @media (max-width: 500px) {


### PR DESCRIPTION
## What
Removes the 3-theme visual switcher (Dark Rose, Midnight Ocean, Amber Dusk) from the app.

## Why
Feature no longer needed — app uses a single permanent Dark Rose theme.

## Changes
- `index.html`: removed `.theme-switcher` div with the three dot buttons
- `app.js`: removed `THEMES` constant, `applyTheme()` function, and `themeSwitcher` click handler
- `style.css`: removed Ocean and Amber theme variable blocks, and `.theme-switcher`/`.theme-dot` styles

## Test on
- [ ] Mobile (Android Chrome or iOS Safari)
- [ ] Desktop browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)